### PR TITLE
Hide vote count properly (#1)

### DIFF
--- a/models/poll.py
+++ b/models/poll.py
@@ -1281,7 +1281,9 @@ class Poll:
 
         # embed = self.add_field_custom(name='**Author**', value=self.author.name, embed=embed)
         await self.load_vote_counts()
-        if self.options_reaction_default:
+        if self.hide_count and self.is_open():
+            embed = self.add_field_custom(name="**Score**", value="*hidden*", embed=embed)
+        elif self.options_reaction_default:
             if await self.is_open():
                 text = f'**Score** '
                 if self.multiple_choice == 0:


### PR DESCRIPTION
The vote count isn't hidden with any of the default options. This patch takes a direct approach to hiding the vote count until the poll is closed.

Open to changes.