### PR TITLE
Fix "No text channels found on this server. Make sure I can see them."

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chardet==3.0.4
 cycler==0.10.0
 dateparser==0.7.4
 dblpy==0.3.4
-discord.py==1.3.3
+discord.py==1.3.4
 idna==2.9
 idna-ssl==1.1.0
 kiwisolver==1.2.0


### PR DESCRIPTION
When PMing the pm!new I encountered a response back from it `No text channels found on this server. Make sure I can see them.` This seems to be upstream related, and that issue was fixed in https://github.com/Rapptz/discord.py/issues/5109 .

Fixed by updating our discord.py to the patched version.