### PR TITLE
Updated PMs to send on all anonymous votes, and to PM when vote removed

### DIFF
--- a/essentials/membercache.py
+++ b/essentials/membercache.py
@@ -11,11 +11,14 @@ class MemberCache:
         self._cache_dict = defaultdict(dict)
 
     async def add(self, guild: discord.Guild, member_id: int) -> discord.Member:
-        member = await guild.fetch_member(member_id)
-        self._cache_dict[guild.id][member_id] = member
-        if len(self._cache_dict[guild.id]) % 1 == 0:
-            logger.info("member cache size: " + str(len(self._cache_dict[guild.id])))
-        return member
+        try:
+            member = await guild.fetch_member(member_id)
+            self._cache_dict[guild.id][member_id] = member
+            if len(self._cache_dict[guild.id]) % 1 == 0:
+                logger.info("member cache size: " + str(len(self._cache_dict[guild.id])))
+            return member
+        except:
+            pass
 
     async def get(self, guild: discord.Guild, member_id: int) -> discord.Member:
         member = self._cache_dict[guild.id].get(member_id, None)

--- a/models/poll.py
+++ b/models/poll.py
@@ -1487,6 +1487,7 @@ class Poll:
             if vote:
                 await vote.delete_from_db()
                 await self.refresh(message)
+                await self.bot.loop.create_task(user.send(f'Your vote for **{self.options_reaction[choice]}** has been REMOVED.'))
                 return
 
         # check if already voted for the same choice
@@ -1524,7 +1525,7 @@ class Poll:
             if not answer or answer.lower() == "-":
                 answer = "No Answer"
 
-        if self.anonymous and self.hide_count:
+        if self.anonymous or self.hide_count:
             self.bot.loop.create_task(user.send(f'Your vote for **{self.options_reaction[choice]}** has been counted.'))
 
         # commit


### PR DESCRIPTION
These changes will send a private message when someone votes on an anonymous poll, regardless if the live count is enabled or not. They will also send a private message under the same conditions if the vote is withdrawn.

Resolves #84 